### PR TITLE
One-line action printing by default, but with command-line 'verbose' format option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.idea/
+.DS_Store
+

--- a/PDDL.py
+++ b/PDDL.py
@@ -6,9 +6,11 @@ from collections import defaultdict
 from action import Action
 
 class PDDL_Parser:
-
+    def __init__(self, action_format):
+        self.action_format = action_format
+        
     SUPPORTED_REQUIREMENTS = [':strips', ':negative-preconditions', ':typing']
-
+    
     #-----------------------------------------------
     # Tokens
     #-----------------------------------------------
@@ -186,7 +188,8 @@ class PDDL_Parser:
             elif t == ':effect':
                 self.split_predicates(group.pop(0), add_effects, del_effects, name, ' effects')
             else: print(str(t) + ' is not recognized in action')
-        self.actions.append(Action(name, parameters, positive_preconditions, negative_preconditions, add_effects, del_effects))
+        self.actions.append(Action(name, parameters, positive_preconditions, negative_preconditions, 
+                                   add_effects, del_effects, self.action_format))
 
     #-----------------------------------------------
     # Parse problem

--- a/PDDL.py
+++ b/PDDL.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from action import Action
 
 class PDDL_Parser:
-    def __init__(self, action_format):
+    def __init__(self, action_format='normal'):
         self.action_format = action_format
         
     SUPPORTED_REQUIREMENTS = [':strips', ':negative-preconditions', ':typing']

--- a/action.py
+++ b/action.py
@@ -3,13 +3,15 @@
 
 import itertools
 
+
 class Action:
 
     #-----------------------------------------------
     # Initialize
     #-----------------------------------------------
 
-    def __init__(self, name, parameters, positive_preconditions, negative_preconditions, add_effects, del_effects):
+    def __init__(self, name, parameters, positive_preconditions, negative_preconditions, add_effects, del_effects,
+                 format='normal'):
         def frozenset_of_tuples(data):
             return frozenset([tuple(t) for t in data])
         self.name = name
@@ -18,18 +20,30 @@ class Action:
         self.negative_preconditions = frozenset_of_tuples(negative_preconditions)
         self.add_effects = frozenset_of_tuples(add_effects)
         self.del_effects = frozenset_of_tuples(del_effects)
+        self.format = format
 
     #-----------------------------------------------
     # to String
     #-----------------------------------------------
 
     def __str__(self):
-        return 'action: ' + self.name + \
-        '\n  parameters: ' + str(self.parameters) + \
-        '\n  positive_preconditions: ' + str([list(i) for i in self.positive_preconditions]) + \
-        '\n  negative_preconditions: ' + str([list(i) for i in self.negative_preconditions]) + \
-        '\n  add_effects: ' + str([list(i) for i in self.add_effects]) + \
-        '\n  del_effects: ' + str([list(i) for i in self.del_effects]) + '\n'
+        if self.format == 'normal':
+            out = self.name + '('
+            params = list(self.parameters)
+            for p in params[:-1]:
+                out += p + ', '
+            if params:
+                out += params[-1] + ')'
+            else:
+                out += ')'
+            return out
+        else:  # format is 'verbose'
+            return 'action: ' + self.name + \
+            '\n  parameters: ' + str(self.parameters) + \
+            '\n  positive_preconditions: ' + str([list(i) for i in self.positive_preconditions]) + \
+            '\n  negative_preconditions: ' + str([list(i) for i in self.negative_preconditions]) + \
+            '\n  add_effects: ' + str([list(i) for i in self.add_effects]) + \
+            '\n  del_effects: ' + str([list(i) for i in self.del_effects]) + '\n'
 
     #-----------------------------------------------
     # Equality
@@ -66,7 +80,8 @@ class Action:
             negative_preconditions = self.replace(self.negative_preconditions, variables, assignment)
             add_effects = self.replace(self.add_effects, variables, assignment)
             del_effects = self.replace(self.del_effects, variables, assignment)
-            yield Action(self.name, assignment, positive_preconditions, negative_preconditions, add_effects, del_effects)
+            yield Action(self.name, assignment, positive_preconditions, negative_preconditions, add_effects, del_effects,
+                         self.format)
 
     #-----------------------------------------------
     # Replace

--- a/action.py
+++ b/action.py
@@ -107,7 +107,8 @@ if __name__ == '__main__':
         [['at', '?ag', '?from'], ['adjacent', '?from', '?to']],
         [['at', '?ag', '?to']],
         [['at', '?ag', '?to']],
-        [['at', '?ag', '?from']]
+        [['at', '?ag', '?from']],
+        'verbose'
     )
     print(a)
 

--- a/planner.py
+++ b/planner.py
@@ -4,7 +4,7 @@
 from PDDL import PDDL_Parser
 
 class Planner:
-    def __init__(self, plan_format):
+    def __init__(self, plan_format='normal'):
         self.plan_format = plan_format
         
     #-----------------------------------------------

--- a/planner.py
+++ b/planner.py
@@ -4,14 +4,16 @@
 from PDDL import PDDL_Parser
 
 class Planner:
-
+    def __init__(self, plan_format):
+        self.plan_format = plan_format
+        
     #-----------------------------------------------
     # Solve
     #-----------------------------------------------
 
     def solve(self, domain, problem):
         # Parser
-        parser = PDDL_Parser()
+        parser = PDDL_Parser(self.plan_format)
         parser.parse_domain(domain)
         parser.parse_problem(problem)
         # Parsed data
@@ -61,15 +63,44 @@ class Planner:
     def apply(self, state, positive, negative):
         return state.difference(negative).union(positive)
 
+
+def display_help():
+    print('usage: python -B planner.py [option] domain_file problem_file')
+    print('Options and arguments:')
+    print('-h:           print this help message and exit (also --help)')
+    print('-f=OPT:       format for printing plan actions (also --format)')
+    print('              OPT is NORMAL or VERBOSE; default is NORMAL.')
+    print('domain_file:  Planning Domain Definition Language (PDDL) domain file')
+    print('problem_file: Planning Domain Definition Language (PDDL) problem file')
+    print()
+
+
 #-----------------------------------------------
 # Main
 #-----------------------------------------------
 if __name__ == '__main__':
     import sys, time
     start_time = time.time()
-    domain = sys.argv[1]
-    problem = sys.argv[2]
-    planner = Planner()
+    narg = len(sys.argv)
+    if narg != 3 and narg != 4:
+        display_help()
+        sys.exit(0)
+    arg1 = sys.argv[1].strip()
+    domain = None
+    problem = None
+    format = 'normal'
+    if arg1 == '--help' or arg1 == '-h':
+        display_help()
+        sys.exit(0)
+    elif arg1.startswith('-f=') or arg1.startswith('--format='):
+        _, format = arg1.split('=')
+        format = format.lower()
+        domain = sys.argv[2]
+        problem = sys.argv[3]
+    else:
+        domain = sys.argv[1]
+        problem = sys.argv[2]
+    planner = Planner(format)
     plan = planner.solve(domain, problem)
     print('Time: ' + str(time.time() - start_time) + 's')
     if plan:


### PR DESCRIPTION
This is a feature to print Actions as one-line by default, but with the command-line option to turn on the prior printing method with its preconditions and effects. If you still like the verbose format as a default, then it's easy enough to switch around the default. Note that I introduced some additional command-line parsing in planner.py to support this (including some help features), but I didn't use any libraries like `optparse` or `argparse` since you indicated you were trying not to use anything but pure Python. Merry Christmas!